### PR TITLE
fix UD aspis arrow limit to match 3.0.2 army book version

### DIFF
--- a/ud.json
+++ b/ud.json
@@ -355,8 +355,8 @@
       "armyHasNotOption": [
         {
           "refs": ["aspis_arrows"],
-          "amount": 20,
-          "perPoints": 750
+          "amount": 10,
+          "perPoints": 400
         },
         {
           "refs": ["death_from_afar"],


### PR DESCRIPTION
Fixes UD's aspis arrow limit to match 3.0.2 army book version